### PR TITLE
Start processing notifications asynchronously

### DIFF
--- a/lib/correspondent/engine.rb
+++ b/lib/correspondent/engine.rb
@@ -2,6 +2,10 @@
 
 module Correspondent
   class Engine < ::Rails::Engine # :nodoc:
+    # Must eager load the notification model
+    require_relative "../../app/models/correspondent/application_record"
+    require_relative "../../app/models/correspondent/notification"
+
     isolate_namespace Correspondent
     config.generators.api_only = true
   end

--- a/test/benchmarks/notifies_penalty_test.rb
+++ b/test/benchmarks/notifies_penalty_test.rb
@@ -11,13 +11,14 @@ module Correspondent
 
       times_slower = how_many_times_slower do
         Benchmark.ips do |x|
+          x.config(time: 1.5, warmup: 1)
           x.report("non-patched") { purchase.dummy }
           x.report("patched") { purchase.purchase }
           x.compare!
         end
       end
 
-      assert_in_delta(8.5, times_slower, 1.5)
+      assert_in_delta(3.5, times_slower, 1.5)
     end
   end
 end

--- a/test/correspondent_test.rb
+++ b/test/correspondent_test.rb
@@ -14,11 +14,11 @@ module Correspondent
       purchase = Purchase.create!(name: "purchase", user: user)
 
       method_source = purchase.method(:purchase).source
-      assert method_source.include?("ActiveSupport::Notifications.instrument")
+      assert method_source.include?("notify_async")
       assert purchase.purchase
 
       method_source = purchase.method(:refund).source
-      assert method_source.include?("ActiveSupport::Notifications.instrument")
+      assert method_source.include?("notify_async")
       assert purchase.refund
     end
 
@@ -31,7 +31,7 @@ module Correspondent
       promotion = Promotion.create!(users: users, name: "promo")
 
       method_source = promotion.method(:promote).source
-      assert method_source.include?("ActiveSupport::Notifications.instrument")
+      assert method_source.include?("notify_async")
       assert promotion.promote
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,14 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures :all
 end
 
+module ActiveSupport
+  class TestCase
+    def teardown
+      Correspondent.threads.each(&:join)
+    end
+  end
+end
+
 # how_many_times_slower
 #
 # Traps $stdout into a StringIO


### PR DESCRIPTION
The ActiveSupport::Notification API is synchronous
and imposed a significant overhead for the patched
methods.

* Start spawning threads to process notifications
* Eager load notification model to avoid loading them in separate threads