### PR TITLE
Use Fiber to process notifications asynchronously

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
 
 Metrics/LineLength:
   Max: 120
+Metrics/MethodLength:
+  Max: 15
 Metrics/BlockLength:
   Exclude:
     - test/**/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    ruby-prof (0.17.0)
     ruby-progressbar (1.10.0)
     sexp_processor (4.11.0)
     simplecov (0.16.1)
@@ -176,6 +177,7 @@ DEPENDENCIES
   purdytest
   rails_best_practices
   rubocop
+  ruby-prof
   simplecov (~> 0.16.1)
   sqlite3 (< 1.4.0)
 

--- a/correspondent.gemspec
+++ b/correspondent.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "purdytest"
   spec.add_development_dependency "rails_best_practices"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "simplecov", "~> 0.16.1"
   spec.add_development_dependency "sqlite3", "< 1.4.0"
 end

--- a/lib/correspondent/engine.rb
+++ b/lib/correspondent/engine.rb
@@ -2,10 +2,6 @@
 
 module Correspondent
   class Engine < ::Rails::Engine # :nodoc:
-    # Must eager load the notification model
-    require_relative "../../app/models/correspondent/application_record"
-    require_relative "../../app/models/correspondent/notification"
-
     isolate_namespace Correspondent
     config.generators.api_only = true
   end

--- a/test/benchmarks/notifies_penalty_test.rb
+++ b/test/benchmarks/notifies_penalty_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "benchmark"
 require "benchmark/ips"
 
 module Correspondent
@@ -11,7 +12,7 @@ module Correspondent
 
       times_slower = how_many_times_slower do
         Benchmark.ips do |x|
-          x.config(time: 1.5, warmup: 1)
+          x.config(time: 5, warmup: 2)
           x.report("non-patched") { purchase.dummy }
           x.report("patched") { purchase.purchase }
           x.compare!
@@ -19,6 +20,21 @@ module Correspondent
       end
 
       assert_in_delta(3.5, times_slower, 1.5)
+    end
+
+    test "the absolute delay time should be smaller than 50ms" do
+      user = User.create!(name: "user", email: "user@email.com")
+      purchase = Purchase.create!(name: "purchase", user: user)
+
+      patched_time = average_exec_time do
+        purchase.purchase
+      end
+
+      normal_time = average_exec_time do
+        purchase.dummy
+      end
+
+      assert patched_time - normal_time < 0.002
     end
   end
 end

--- a/test/correspondent_test.rb
+++ b/test/correspondent_test.rb
@@ -14,11 +14,11 @@ module Correspondent
       purchase = Purchase.create!(name: "purchase", user: user)
 
       method_source = purchase.method(:purchase).source
-      assert method_source.include?("notify_async")
+      assert method_source.include?("Correspondent <<")
       assert purchase.purchase
 
       method_source = purchase.method(:refund).source
-      assert method_source.include?("notify_async")
+      assert method_source.include?("Correspondent <<")
       assert purchase.refund
     end
 
@@ -31,7 +31,7 @@ module Correspondent
       promotion = Promotion.create!(users: users, name: "promo")
 
       method_source = promotion.method(:promote).source
-      assert method_source.include?("notify_async")
+      assert method_source.include?("Correspondent <<")
       assert promotion.promote
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,14 +27,6 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures :all
 end
 
-module ActiveSupport
-  class TestCase
-    def teardown
-      Correspondent.threads.each(&:join)
-    end
-  end
-end
-
 # how_many_times_slower
 #
 # Traps $stdout into a StringIO
@@ -49,4 +41,16 @@ def how_many_times_slower
 
   $stdout = original_stdout
   benchmark.string.scan(/(?<=- )[\d.]+(?=x\s+slower)/).first.to_f
+end
+
+# average_exec_time
+#
+# Calculate average execution time
+# for a given block.
+def average_exec_time
+  (0...1000).map do
+    Benchmark.measure do
+      yield
+    end.real
+  end.reduce(:+) / 1000
 end


### PR DESCRIPTION
Having a Fiber to process the notifications queue asynchronsouly
causes less overhead than instantiating many threads. It should
also be more memory efficient.