### PR TITLE
Refactor notifies to accept multiple entities

### DIFF
--- a/test/dummy/app/models/purchase.rb
+++ b/test/dummy/app/models/purchase.rb
@@ -1,7 +1,8 @@
 class Purchase < ApplicationRecord
   belongs_to :user
   has_many :notifications, class_name: "Correspondent::Notification", as: :publisher
-  notifies :user, %i[purchase refund], mailer: ApplicationMailer
+  notifies :user, %i[purchase], mailer: ApplicationMailer
+  notifies :user, :refund, mailer: ApplicationMailer
 
   def purchase
     true


### PR DESCRIPTION
Calling notifies with different arguments on the same model
would overwrite definitions and cause unexpected behavior.
It is now possible to have multiple notifies definitions for
many entities or triggers with distinct options.